### PR TITLE
Upgraded code to Java 8 and Joda time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Currently fixio can beat QuickFix performance in simple scenario. See [performan
 <dependency>
     <groupId>kpavlov.fixio</groupId>
     <artifactId>core</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 </dependency>
 ~~~~~~~~~
 
@@ -51,7 +51,7 @@ You'll also need a slf4j API implementation at runtime, so please add appropriat
 <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-simple</artifactId>
-    <version>1.7.5</version>
+    <version>1.7.10</version>
     <scope>runtime</scope>
     <optional>true</optional>
 </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>fixio</artifactId>
         <groupId>kpavlov.fixio</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -46,6 +46,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -63,7 +68,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/fixio/FixClient.java
+++ b/core/src/main/java/fixio/FixClient.java
@@ -81,7 +81,7 @@ public class FixClient extends AbstractFixConnector {
     public ChannelFuture connect(SocketAddress serverAddress) throws InterruptedException {
         Bootstrap b = new Bootstrap();
         bossEventLoopGroup = new NioEventLoopGroup();
-        workerEventLoopGroup = new NioEventLoopGroup(8);
+        workerEventLoopGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors());
         b.group(bossEventLoopGroup)
                 .channel(NioSocketChannel.class)
                 .remoteAddress(serverAddress)

--- a/core/src/main/java/fixio/FixServer.java
+++ b/core/src/main/java/fixio/FixServer.java
@@ -55,7 +55,7 @@ public class FixServer extends AbstractFixConnector {
 
     public void start() throws InterruptedException {
         bossGroup = new NioEventLoopGroup();
-        workerGroup = new NioEventLoopGroup(8);
+        workerGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors());
         final ServerBootstrap bootstrap = new ServerBootstrap();
         final FixAcceptorChannelInitializer<SocketChannel> channelInitializer = new FixAcceptorChannelInitializer<>(
                 workerGroup,

--- a/core/src/main/java/fixio/events/AbstractAdminEvent.java
+++ b/core/src/main/java/fixio/events/AbstractAdminEvent.java
@@ -33,13 +33,9 @@ public abstract class AbstractAdminEvent implements AdminEvent {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AbstractAdminEvent that = (AbstractAdminEvent) o;
-
-        if (!session.equals(that.session)) return false;
-
-        return true;
+        if (!(o instanceof AbstractAdminEvent)) return false;
+        final AbstractAdminEvent that = (AbstractAdminEvent) o;
+        return session.equals(that.session);
     }
 
     @Override

--- a/core/src/main/java/fixio/fixprotocol/Group.java
+++ b/core/src/main/java/fixio/fixprotocol/Group.java
@@ -177,7 +177,7 @@ public class Group implements FieldListBuilder<Group> {
         StringBuilder sb = new StringBuilder();
         for (FixMessageFragment fragment : contents.values()){
             int tagNum = fragment.getTagNum();
-            sb.append(FieldType.forTag(tagNum) + "(" + tagNum + ")=" + fragment.getValue()).append(", ");
+            sb.append(FieldType.forTag(tagNum)).append("(").append(tagNum).append(")=").append(fragment.getValue()).append(", ");
         }
         return sb.toString();
     }

--- a/core/src/main/java/fixio/fixprotocol/GroupField.java
+++ b/core/src/main/java/fixio/fixprotocol/GroupField.java
@@ -17,7 +17,6 @@ package fixio.fixprotocol;
 
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -61,9 +60,7 @@ public class GroupField implements FixMessageFragment<List<Group>> {
         int tagNum = getTagNum();
         StringBuilder sb = new StringBuilder().append(FieldType.forTag(tagNum)).append("(").append(tagNum).append(")=").append(getGroupCount());
         sb.append("[");
-        for (Group group : groups) {
-            sb.append(group);
-        }
+        groups.forEach(sb::append);
         sb.append("]");
         return sb.toString();
     }

--- a/core/src/main/java/fixio/fixprotocol/fields/FixedPointNumber.java
+++ b/core/src/main/java/fixio/fixprotocol/fields/FixedPointNumber.java
@@ -100,7 +100,8 @@ public class FixedPointNumber extends Number {
         return scaledValue / ((long) Math.pow(10.0, scale));
     }
 
-    @Override@Deprecated
+    @Override
+    @Deprecated
     public float floatValue() {
         return (float) doubleValue();
     }
@@ -121,15 +122,12 @@ public class FixedPointNumber extends Number {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        FixedPointNumber that = (FixedPointNumber) o;
-
-        if (scale != that.scale) return false;
-        if (scaledValue != that.scaledValue) return false;
-
-        return true;
+        if (this == o)
+            return true;
+        if (o == null || !(o instanceof FixedPointNumber))
+            return false;
+        final FixedPointNumber that = (FixedPointNumber) o;
+        return scale == that.scale && scaledValue == that.scaledValue;
     }
 
     @Override
@@ -139,9 +137,9 @@ public class FixedPointNumber extends Number {
         return result;
     }
 
-    private String insertPointBefore(int idx){
+    private String insertPointBefore(int idx) {
         StringBuilder sb = new StringBuilder("0.");
-        for (int i=idx ; i<0 ; i++){
+        for (int i = idx; i < 0; i++) {
             sb.append("0");
         }
         return sb.toString();
@@ -161,15 +159,15 @@ public class FixedPointNumber extends Number {
             return "-0." + afterPoint;
         } else {
 //            return beforePoint + "." + afterPoint;
-            int idx = scaledStr.length()-scale;
+            int idx = scaledStr.length() - scale;
             String insertPoint;
-            if (idx <= 0){
+            if (idx <= 0) {
                 insertPoint = insertPointBefore(idx);
                 idx = 0;
-            } else{
+            } else {
                 insertPoint = ".";
             }
-            return new StringBuilder(scaledStr).insert(idx,insertPoint).toString();
+            return new StringBuilder(scaledStr).insert(idx, insertPoint).toString();
         }
     }
 }

--- a/core/src/main/java/fixio/fixprotocol/session/SessionId.java
+++ b/core/src/main/java/fixio/fixprotocol/session/SessionId.java
@@ -57,21 +57,9 @@ public class SessionId {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         SessionId other = (SessionId) o;
+        return this.hashCode() == other.hashCode() && senderCompID.equals(other.senderCompID) && !(senderSubID != null ? !senderSubID.equals(other.senderSubID) : other.senderSubID != null) && targetCompID.equals(other.targetCompID) && !(targetSubID != null ? !targetSubID.equals(other.targetSubID) : other.targetSubID != null);
 
-        if (this.hashCode() != other.hashCode()) {
-            return false;
-        }
-
-        if (!senderCompID.equals(other.senderCompID)) return false;
-        if (senderSubID != null ? !senderSubID.equals(other.senderSubID) : other.senderSubID != null)
-            return false;
-        if (!targetCompID.equals(other.targetCompID)) return false;
-        if (targetSubID != null ? !targetSubID.equals(other.targetSubID) : other.targetSubID != null)
-            return false;
-
-        return true;
     }
 
     @Override

--- a/core/src/main/java/fixio/netty/pipeline/AbstractSessionHandler.java
+++ b/core/src/main/java/fixio/netty/pipeline/AbstractSessionHandler.java
@@ -35,16 +35,14 @@ public abstract class AbstractSessionHandler extends MessageToMessageCodec<FixMe
 
     public static final AttributeKey<FixSession> FIX_SESSION_KEY = AttributeKey.valueOf("fixSession");
     private final FixApplication fixApplication;
-    private final Clock clock;
+    private final FixClock fixClock;
     private final SessionRepository sessionRepository;
 
-    protected AbstractSessionHandler(FixApplication fixApplication,
-                                     Clock clock,
-                                     SessionRepository sessionRepository) {
+    protected AbstractSessionHandler(FixApplication fixApplication, FixClock fixClock, SessionRepository sessionRepository) {
         assert (fixApplication != null) : "FixApplication is required";
-        assert (clock != null) : "Clock is required";
+        assert (fixClock != null) : "Clock is required";
         this.fixApplication = fixApplication;
-        this.clock = clock;
+        this.fixClock = fixClock;
         this.sessionRepository = sessionRepository;
     }
 
@@ -69,7 +67,7 @@ public abstract class AbstractSessionHandler extends MessageToMessageCodec<FixMe
     protected void prepareMessageToSend(ChannelHandlerContext ctx, FixSession session, FixMessageBuilder response) throws Exception {
         session.prepareOutgoing(response);
         getFixApplication().beforeSendMessage(ctx, response);
-        response.getHeader().setSendingTime(clock.millis());
+        response.getHeader().setSendingTime(fixClock.millis());
     }
 
     /**

--- a/core/src/main/java/fixio/netty/pipeline/FixClock.java
+++ b/core/src/main/java/fixio/netty/pipeline/FixClock.java
@@ -15,22 +15,28 @@
  */
 package fixio.netty.pipeline;
 
+import java.time.Clock;
 
 /**
- * JDK 8 compatible API.
+ * Fix clock that uses Java 8 system UTC clock by default,
+ * it should be easy to add other time zones clock using
+ * Java 8 time API.
  */
-public class Clock {
+public class FixClock {
 
-    private static final Clock INSTANCE = new Clock();
+    private static final FixClock INSTANCE = new FixClock(Clock.systemUTC());
 
-    private Clock() {
+    private final Clock clock;
+
+    private FixClock(Clock clock) {
+        this.clock = clock;
     }
 
-    public static Clock systemUTC() {
+    public static FixClock systemUTC() {
         return INSTANCE;
     }
 
     public long millis() {
-        return System.currentTimeMillis();
+        return clock.millis();
     }
 }

--- a/core/src/main/java/fixio/netty/pipeline/server/ServerSessionHandler.java
+++ b/core/src/main/java/fixio/netty/pipeline/server/ServerSessionHandler.java
@@ -21,7 +21,7 @@ import fixio.fixprotocol.*;
 import fixio.fixprotocol.session.FixSession;
 import fixio.handlers.FixApplication;
 import fixio.netty.pipeline.AbstractSessionHandler;
-import fixio.netty.pipeline.Clock;
+import fixio.netty.pipeline.FixClock;
 import fixio.netty.pipeline.SessionRepository;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -39,7 +39,7 @@ public class ServerSessionHandler extends AbstractSessionHandler {
     public ServerSessionHandler(FixApplication fixApplication,
                                 FixAuthenticator authenticator,
                                 SessionRepository sessionRepository) {
-        super(fixApplication, Clock.systemUTC(), sessionRepository);
+        super(fixApplication, FixClock.systemUTC(), sessionRepository);
         assert (authenticator != null) : "FixAuthenticator is required for ServerSessionHandler";
         this.authenticator = authenticator;
     }

--- a/core/src/test/java/fixio/fixprotocol/fields/FieldFactoryTest.java
+++ b/core/src/test/java/fixio/fixprotocol/fields/FieldFactoryTest.java
@@ -17,16 +17,17 @@ package fixio.fixprotocol.fields;
 
 import fixio.fixprotocol.DataType;
 import fixio.fixprotocol.FieldType;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
 import java.util.Random;
-import java.util.TimeZone;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.apache.commons.lang3.RandomStringUtils.randomAscii;
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.*;
 
 public class FieldFactoryTest {
@@ -168,19 +169,7 @@ public class FieldFactoryTest {
         UTCTimestampField field = FieldFactory.valueOf(FieldType.OrigTime.tag(), value.getBytes(US_ASCII));
 
         assertEquals("tagnum", FieldType.OrigTime.tag(), field.getTagNum());
-
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.set(Calendar.YEAR, 1998);
-        calendar.set(Calendar.MONTH, Calendar.JUNE);
-        calendar.set(Calendar.DAY_OF_MONTH, 4);
-        calendar.set(Calendar.HOUR_OF_DAY, 8);
-        calendar.set(Calendar.MINUTE, 3);
-        calendar.set(Calendar.SECOND, 31);
-        calendar.set(Calendar.MILLISECOND, 537);
-        long timeInMillis = calendar.getTimeInMillis();
-
-        assertEquals("value", timeInMillis, field.getValue().longValue());
-        assertEquals("value", timeInMillis, field.timestampMillis());
+        assertEquals("value", new LocalDate(1998, 6, 4).toDateTime(new LocalTime(8, 3, 31, 537), UTC).getMillis(), field.getValue().longValue());
     }
 
     @Test
@@ -189,19 +178,7 @@ public class FieldFactoryTest {
         UTCTimestampField field = FieldFactory.valueOf(FieldType.OrigTime.tag(), value.getBytes(US_ASCII));
 
         assertEquals("tagnum", FieldType.OrigTime.tag(), field.getTagNum());
-
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.set(Calendar.YEAR, 1998);
-        calendar.set(Calendar.MONTH, Calendar.JUNE);
-        calendar.set(Calendar.DAY_OF_MONTH, 4);
-        calendar.set(Calendar.HOUR_OF_DAY, 8);
-        calendar.set(Calendar.MINUTE, 3);
-        calendar.set(Calendar.SECOND, 31);
-        calendar.set(Calendar.MILLISECOND, 0);
-        long timeInMillis = calendar.getTimeInMillis();
-
-        assertEquals("value", timeInMillis, field.getValue().longValue());
-        assertEquals("value", timeInMillis, field.timestampMillis());
+        assertEquals("value", new LocalDate(1998, 6, 4).toDateTime(new LocalTime(8, 3, 31, 0), UTC).getMillis(), field.getValue().longValue());
     }
 
     @Test

--- a/core/src/test/java/fixio/fixprotocol/fields/UTCDateOnlyFieldTest.java
+++ b/core/src/test/java/fixio/fixprotocol/fields/UTCDateOnlyFieldTest.java
@@ -15,43 +15,31 @@
  */
 package fixio.fixprotocol.fields;
 
-import org.junit.Before;
+import org.joda.time.LocalDate;
 import org.junit.Test;
 
-import java.util.Calendar;
 import java.util.Random;
-import java.util.TimeZone;
 
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class UTCDateOnlyFieldTest {
 
     private static final String DATE_STR = "19980604";
-    private Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 
-    @Before
-    public void setUp() {
-        utcCalendar.set(Calendar.YEAR, 1998);
-        utcCalendar.set(Calendar.MONTH, Calendar.JUNE);
-        utcCalendar.set(Calendar.DAY_OF_MONTH, 4);
-        utcCalendar.clear(Calendar.HOUR_OF_DAY);
-        utcCalendar.clear(Calendar.MINUTE);
-        utcCalendar.clear(Calendar.SECOND);
-        utcCalendar.clear(Calendar.MILLISECOND);
-    }
+    private final LocalDate testDate = new LocalDate(1998, 6, 4);
 
     @Test
     public void testParse() throws Exception {
-        assertEquals(utcCalendar.getTimeInMillis(), UTCDateOnlyField.parse((DATE_STR.getBytes())));
+        assertEquals(testDate.toDateTimeAtCurrentTime(UTC).getMillis(), UTCDateOnlyField.parse((DATE_STR.getBytes())));
     }
 
     @Test
     public void testCreate() throws Exception {
         int tag = new Random().nextInt();
         UTCDateOnlyField field = new UTCDateOnlyField(tag, DATE_STR.getBytes());
-        assertEquals(utcCalendar.getTimeInMillis(), field.getValue().longValue());
-        assertEquals(utcCalendar.getTimeInMillis(), field.timestampMillis());
+        assertEquals(testDate.toDateTimeAtCurrentTime(UTC).getMillis(), field.getValue().longValue());
     }
 
     @Test
@@ -59,7 +47,6 @@ public class UTCDateOnlyFieldTest {
         int tag = new Random().nextInt();
         byte[] bytes = DATE_STR.getBytes();
         UTCDateOnlyField field = new UTCDateOnlyField(tag, bytes);
-
         assertArrayEquals(bytes, field.getBytes());
     }
 }

--- a/core/src/test/java/fixio/fixprotocol/fields/UTCTimeOnlyFieldTest.java
+++ b/core/src/test/java/fixio/fixprotocol/fields/UTCTimeOnlyFieldTest.java
@@ -15,13 +15,15 @@
  */
 package fixio.fixprotocol.fields;
 
-import org.junit.Before;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.junit.Test;
 
-import java.util.Calendar;
 import java.util.Random;
-import java.util.TimeZone;
 
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -33,51 +35,36 @@ public class UTCTimeOnlyFieldTest {
     private static final long MILLIS_PER_MINUTE = 60 * MILLIS_PER_SECOND;
     private static final long MILLIS_PER_HOUR = 60 * MILLIS_PER_MINUTE;
 
-    private Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-
-    @Before
-    public void setUp() {
-        utcCalendar.set(Calendar.YEAR, 1970);
-        utcCalendar.set(Calendar.MONTH, 0);
-        utcCalendar.set(Calendar.DAY_OF_MONTH, 1);
-        utcCalendar.set(Calendar.HOUR_OF_DAY, 8);
-        utcCalendar.set(Calendar.MINUTE, 3);
-        utcCalendar.set(Calendar.SECOND, 31);
-        utcCalendar.clear(Calendar.MILLISECOND);
-    }
+    private final DateTime testDate = new LocalDate(1970, 1, 1).toDateTime(new LocalTime(8, 3, 31, 0), UTC);
 
     @Test
     public void testParseNoMillis() throws Exception {
-        assertEquals(utcCalendar.getTimeInMillis(), UTCTimeOnlyField.parse(TIMESTAMP_NO_MILLIS.getBytes()));
+        assertEquals(testDate.getMillis(), UTCTimeOnlyField.parse(TIMESTAMP_NO_MILLIS.getBytes()));
     }
 
     @Test
     public void testParseWithMillis() throws Exception {
-        utcCalendar.set(Calendar.MILLISECOND, 537);
-        assertEquals(utcCalendar.getTimeInMillis(), UTCTimeOnlyField.parse((TIMESTAMP_WITH_MILLIS.getBytes())));
+        assertEquals(testDate.withField(DateTimeFieldType.millisOfSecond(), 537).getMillis(), UTCTimeOnlyField.parse((TIMESTAMP_WITH_MILLIS.getBytes())));
     }
 
     @Test
     public void testParseLastMillisecond() throws Exception {
-        long lastMillisecondOfDay = MILLIS_PER_HOUR * 24 - 1;
-        assertEquals(lastMillisecondOfDay, UTCTimeOnlyField.parse(("23:59:59.999".getBytes())));
+        long lastMilliSecondOfDay = MILLIS_PER_HOUR * 24 - 1;
+        assertEquals(lastMilliSecondOfDay, UTCTimeOnlyField.parse(("23:59:59.999".getBytes())));
     }
 
     @Test
     public void testCreateNoMillis() throws Exception {
         int tag = new Random().nextInt();
         UTCTimeOnlyField field = new UTCTimeOnlyField(tag, TIMESTAMP_NO_MILLIS.getBytes());
-        assertEquals(utcCalendar.getTimeInMillis(), field.getValue().longValue());
-        assertEquals(utcCalendar.getTimeInMillis(), field.timestampMillis());
+        assertEquals(testDate.getMillis(), field.getValue().longValue());
     }
 
     @Test
     public void testCreateWithMillis() throws Exception {
         int tag = new Random().nextInt();
-        utcCalendar.set(Calendar.MILLISECOND, 537);
         UTCTimeOnlyField field = new UTCTimeOnlyField(tag, TIMESTAMP_WITH_MILLIS.getBytes());
-        assertEquals(utcCalendar.getTimeInMillis(), field.getValue().longValue());
-        assertEquals(utcCalendar.getTimeInMillis(), field.timestampMillis());
+        assertEquals(testDate.withField(DateTimeFieldType.millisOfSecond(), 537).getMillis(), field.getValue().longValue());
     }
 
     @Test

--- a/core/src/test/java/fixio/fixprotocol/fields/UTCTimestampFieldTest.java
+++ b/core/src/test/java/fixio/fixprotocol/fields/UTCTimestampFieldTest.java
@@ -15,13 +15,15 @@
  */
 package fixio.fixprotocol.fields;
 
-import org.junit.Before;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.junit.Test;
 
-import java.util.Calendar;
 import java.util.Random;
-import java.util.TimeZone;
 
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -30,28 +32,16 @@ public class UTCTimestampFieldTest {
     private static final String TIMESTAMP_WITH_MILLIS = "19980604-08:03:31.537";
     private static final String TIMESTAMP_NO_MILLIS = "19980604-08:03:31";
 
-    private Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-
-    @Before
-    public void setUp() {
-        utcCalendar.set(Calendar.YEAR, 1998);
-        utcCalendar.set(Calendar.MONTH, Calendar.JUNE);
-        utcCalendar.set(Calendar.DAY_OF_MONTH, 4);
-        utcCalendar.set(Calendar.HOUR_OF_DAY, 8);
-        utcCalendar.set(Calendar.MINUTE, 3);
-        utcCalendar.set(Calendar.SECOND, 31);
-        utcCalendar.clear(Calendar.MILLISECOND);
-    }
+    private final DateTime testDate = new LocalDate(1998, 6, 4).toDateTime(new LocalTime(8, 3, 31, 0), UTC);
 
     @Test
     public void testParseNoMillis() throws Exception {
-        assertEquals(utcCalendar.getTimeInMillis(), UTCTimestampField.parse(TIMESTAMP_NO_MILLIS.getBytes()));
+        assertEquals(testDate.getMillis(), UTCTimestampField.parse(TIMESTAMP_NO_MILLIS.getBytes()));
     }
 
     @Test
     public void testParseWithMillis() throws Exception {
-        utcCalendar.set(Calendar.MILLISECOND, 537);
-        assertEquals(utcCalendar.getTimeInMillis(), UTCTimestampField.parse((TIMESTAMP_WITH_MILLIS.getBytes())));
+        assertEquals(testDate.withField(DateTimeFieldType.millisOfSecond(), 537).getMillis(), UTCTimestampField.parse((TIMESTAMP_WITH_MILLIS.getBytes())));
     }
 
     @Test
@@ -59,18 +49,15 @@ public class UTCTimestampFieldTest {
         int tag = new Random().nextInt();
         byte[] bytes = TIMESTAMP_NO_MILLIS.getBytes();
         UTCTimestampField field = new UTCTimestampField(tag, bytes, 0, bytes.length);
-        assertEquals(utcCalendar.getTimeInMillis(), field.getValue().longValue());
-        assertEquals(utcCalendar.getTimeInMillis(), field.timestampMillis());
+        assertEquals(testDate.getMillis(), field.getValue().longValue());
     }
 
     @Test
     public void testCreateWithMillis() throws Exception {
         int tag = new Random().nextInt();
-        utcCalendar.set(Calendar.MILLISECOND, 537);
         byte[] bytes = TIMESTAMP_WITH_MILLIS.getBytes();
         UTCTimestampField field = new UTCTimestampField(tag, bytes, 0, bytes.length);
-        assertEquals(utcCalendar.getTimeInMillis(), field.getValue().longValue());
-        assertEquals(utcCalendar.getTimeInMillis(), field.timestampMillis());
+        assertEquals(testDate.withField(DateTimeFieldType.millisOfSecond(), 537).getMillis(), field.getValue().longValue());
     }
 
     @Test

--- a/core/src/test/java/fixio/netty/codec/FixMessageDecoderTest.java
+++ b/core/src/test/java/fixio/netty/codec/FixMessageDecoderTest.java
@@ -21,16 +21,17 @@ import fixio.fixprotocol.FixMessageImpl;
 import fixio.fixprotocol.MessageTypes;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.DecoderException;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalTime;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
-import java.util.TimeZone;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.Assert.*;
 
 public class FixMessageDecoderTest {
@@ -59,15 +60,8 @@ public class FixMessageDecoderTest {
         assertEquals(240, header.getMsgSeqNum());
         assertEquals(129, fixMessage.getChecksum());
 
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.set(Calendar.YEAR, 1998);
-        calendar.set(Calendar.MONTH, Calendar.JUNE);
-        calendar.set(Calendar.DAY_OF_MONTH, 4);
-        calendar.set(Calendar.HOUR_OF_DAY, 8);
-        calendar.set(Calendar.MINUTE, 3);
-        calendar.set(Calendar.SECOND, 31);
-        calendar.set(Calendar.MILLISECOND, 0);
-        assertEquals(calendar.getTimeInMillis(), (long)fixMessage.getValue(FieldType.SendingTime));
+        final Long value = fixMessage.getValue(FieldType.SendingTime);
+        assertEquals(new LocalDate(1998, 6, 4).toDateTime(new LocalTime(8, 3, 31, 0), UTC).getMillis(), value.longValue());
     }
 
     @Test
@@ -90,13 +84,13 @@ public class FixMessageDecoderTest {
 
     @Test
     public void testNoBeginTag() throws Exception {
-        String random=randomAlphanumeric(50);
+        String random = randomAlphanumeric(50);
 
         try {
             decode("100=" + random + "\u00018=FIX.4.2...");
             fail("DecoderException is expected");
         } catch (DecoderException e) {
-            assertEquals("BeginString tag expected, but got: 100=" + random.substring(0,10) + "...", e.getMessage());
+            assertEquals("BeginString tag expected, but got: 100=" + random.substring(0, 10) + "...", e.getMessage());
         }
     }
 }

--- a/core/src/test/java/fixio/netty/pipeline/AbstractSessionHandlerTest.java
+++ b/core/src/test/java/fixio/netty/pipeline/AbstractSessionHandlerTest.java
@@ -67,7 +67,7 @@ public class AbstractSessionHandlerTest {
 
     @Before
     public void setUp() {
-        sessionHandler = new AbstractSessionHandler(fixApplication, Clock.systemUTC(), sessionRepository) {
+        sessionHandler = new AbstractSessionHandler(fixApplication, FixClock.systemUTC(), sessionRepository) {
             @Override
             protected void encode(ChannelHandlerContext ctx, FixMessageBuilder msg, List<Object> out) throws Exception {
             }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>fixio</artifactId>
         <groupId>kpavlov.fixio</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/src/main/java/fixio/examples/priceserver/PriceStreamingApp.java
+++ b/examples/src/main/java/fixio/examples/priceserver/PriceStreamingApp.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 class PriceStreamingApp extends FixApplicationAdapter {
 
@@ -67,14 +68,8 @@ class PriceStreamingApp extends FixApplicationAdapter {
 
     private void stopStreaming(ChannelHandlerContext ctx) {
         ArrayList<String> requestsToCancel = new ArrayList<>(subscriptions.size());
-        for (Map.Entry<String, ChannelHandlerContext> entry : subscriptions.entrySet()) {
-            if (entry.getValue() == ctx) {
-                requestsToCancel.add(entry.getKey());
-            }
-        }
-        for (String reqId : requestsToCancel) {
-            subscriptions.remove(reqId);
-        }
+        requestsToCancel.addAll(subscriptions.entrySet().stream().filter(entry -> entry.getValue() == ctx).map(Map.Entry::getKey).collect(Collectors.toList()));
+        requestsToCancel.forEach(subscriptions::remove);
         LOGGER.info("Streaming Stopped for {}", ctx);
     }
 

--- a/examples/src/main/java/fixio/examples/quickfix/QuickFixStreamingApp.java
+++ b/examples/src/main/java/fixio/examples/quickfix/QuickFixStreamingApp.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class QuickFixStreamingApp implements Application {
     private static final Logger LOGGER = LoggerFactory.getLogger(QuickFixStreamingApp.class);
@@ -102,14 +103,8 @@ public class QuickFixStreamingApp implements Application {
 
     private void stopStreaming(SessionID sessionID) {
         ArrayList<String> requestsToCancel = new ArrayList<>(subscriptions.size());
-        for (Map.Entry<String, SessionID> entry : subscriptions.entrySet()) {
-            if (entry.getValue() == sessionID) {
-                requestsToCancel.add(entry.getKey());
-            }
-        }
-        for (String reqId : requestsToCancel) {
-            subscriptions.remove(reqId);
-        }
+        requestsToCancel.addAll(subscriptions.entrySet().stream().filter(entry -> entry.getValue() == sessionID).map(Map.Entry::getKey).collect(Collectors.toList()));
+        requestsToCancel.forEach(subscriptions::remove);
         LOGGER.info("Streaming Stopped for {}", sessionID);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>kpavlov.fixio</groupId>
     <artifactId>fixio</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <name>fix.io</name>
     <description>FIX Protocol Support for Netty</description>
@@ -30,6 +30,7 @@
     <properties>
         <slf4j.version>1.7.10</slf4j.version>
         <netty.version>4.0.25.Final</netty.version>
+        <joda.version>2.7</joda.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
I have rebased my branch from your current master so that you don't have to resolve conflicts, tests passed but NPE at some test:
```
ERROR FixApplicationAdapter - Uncaught application exception.
io.netty.handler.codec.DecoderException: java.lang.NullPointerException
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:99)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:283)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:187)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.access$600(AbstractChannelHandlerContext.java:32)
	at io.netty.channel.AbstractChannelHandlerContext$7.run(AbstractChannelHandlerContext.java:299)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:380)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
	at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NullPointerException
	at fixio.netty.pipeline.server.ServerSessionHandler.initSession(ServerSessionHandler.java:122)
	at fixio.netty.pipeline.server.ServerSessionHandler.decode(ServerSessionHandler.java:76)
	at fixio.netty.pipeline.server.ServerSessionHandler.decode(ServerSessionHandler.java:33)
	at io.netty.handler.codec.MessageToMessageCodec$2.decode(MessageToMessageCodec.java:81)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:89)
	... 18 more
```