### PR TITLE
Allow session settings to store custom properties.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/fixio/netty/pipeline/client/FixSessionSettingsProvider.java
+++ b/core/src/main/java/fixio/netty/pipeline/client/FixSessionSettingsProvider.java
@@ -31,4 +31,6 @@ public interface FixSessionSettingsProvider {
     boolean isResetMsgSeqNum();
 
     int getHeartbeatInterval();
+
+    String getProperty(String key, String defaultValue);
 }

--- a/core/src/main/java/fixio/netty/pipeline/client/PropertyFixSessionSettingsProviderImpl.java
+++ b/core/src/main/java/fixio/netty/pipeline/client/PropertyFixSessionSettingsProviderImpl.java
@@ -82,4 +82,9 @@ public class PropertyFixSessionSettingsProviderImpl implements FixSessionSetting
     public String getBeginString() {
         return properties.getProperty("BeginString");
     }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        return properties.getProperty(key, defaultValue);
+    }
 }

--- a/core/src/main/java/fixio/netty/pipeline/client/SimpleFixSessionSettingsProvider.java
+++ b/core/src/main/java/fixio/netty/pipeline/client/SimpleFixSessionSettingsProvider.java
@@ -92,4 +92,9 @@ public class SimpleFixSessionSettingsProvider implements FixSessionSettingsProvi
     public void setHeartbeatInterval(int heartbeatInterval) {
         this.heartbeatInterval = heartbeatInterval;
     }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        throw new UnsupportedOperationException("Get custom property operation not supported");
+    }
 }


### PR DESCRIPTION
Allow sessions to store and use custom properties which later can be used once FIX events are triggered.