### PR TITLE
Channel is sometimes not visible to initiator thread causing a NPE.

### DIFF
--- a/core/src/main/java/fixio/FixClient.java
+++ b/core/src/main/java/fixio/FixClient.java
@@ -79,9 +79,9 @@ public class FixClient extends AbstractFixConnector {
     }
 
     public ChannelFuture connect(SocketAddress serverAddress) throws InterruptedException {
-        connectAsync(serverAddress).sync().await();
-        LOGGER.info("FixClient is started and connected to {}", channel.remoteAddress());
+        final Channel channel = connectAsync(serverAddress).sync().await().channel();
         assert (channel != null) : "Channel must be set";
+        LOGGER.info("FixClient is started and connected to {}", channel.remoteAddress());
         return channel.closeFuture();
     }
 


### PR DESCRIPTION
Channel is sometimes not visible to initiator thread causing a NPE, making channel volatile would be over-killing, instead I'm using a `Channel` local variable returned from the Netty future and that solves the problem, if `Channel` is still not visible later for multi-threaded applications then it will have to be converted into a `volatile` variable, I'm using Akka for a high performance and message oriented trading system so there I get the problem because I initialize my `FixClient` at construction time and start the connection later.

**Note:** Problem hard to reproduce.