### PR TITLE
Replace use of java.util.Map with a primitive map

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,13 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>7.0.12</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/core/src/main/java/fixio/fixprotocol/FieldListBuilderHelper.java
+++ b/core/src/main/java/fixio/fixprotocol/FieldListBuilderHelper.java
@@ -18,8 +18,7 @@ package fixio.fixprotocol;
 import fixio.fixprotocol.fields.CharField;
 import fixio.fixprotocol.fields.FieldFactory;
 import fixio.fixprotocol.fields.FixedPointNumber;
-
-import java.util.Map;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 
 /**
  * Helper class for managing {@link FieldListBuilder}.
@@ -31,60 +30,60 @@ final class FieldListBuilderHelper {
 
     // From Int
 
-    static void add(Map<Integer, FixMessageFragment> map, DataType type, int tagNum, int value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, DataType type, int tagNum, int value) {
         assert (tagNum > 0) : "Tag must be positive.";
         map.put(tagNum, FieldFactory.fromIntValue(type, tagNum, value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, int tagNum, int value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, int tagNum, int value) {
         assert (tagNum > 0) : "Tag must be positive.";
         map.put(tagNum, FieldFactory.fromIntValue(tagNum, value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, FieldType fieldType, int value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, FieldType fieldType, int value) {
         assert (fieldType != null) : "Tag must be specified.";
         map.put(fieldType.tag(), FieldFactory.fromIntValue(fieldType.type(), fieldType.tag(), value));
     }
 
     // From Long
 
-    static void add(Map<Integer, FixMessageFragment> map, DataType type, int tagNum, long value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, DataType type, int tagNum, long value) {
         assert (tagNum > 0) : "Tag must be positive.";
         map.put(tagNum, FieldFactory.fromLongValue(type, tagNum, value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, int tagNum, long value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, int tagNum, long value) {
         assert (tagNum > 0) : "Tag must be positive.";
         map.put(tagNum, FieldFactory.fromLongValue(tagNum, value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, FieldType fieldType, long value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, FieldType fieldType, long value) {
         assert (fieldType != null) : "Tag must be specified.";
         map.put(fieldType.tag(), FieldFactory.fromLongValue(fieldType.type(), fieldType.tag(), value));
     }
 
     // From String
 
-    static void add(Map<Integer, FixMessageFragment> map, FieldType fieldType, String value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, FieldType fieldType, String value) {
         assert (fieldType != null) : "Tag must be specified.";
         assert (value != null) : "Value must be specified.";
         map.put(fieldType.tag(), FieldFactory.fromStringValue(fieldType.type(), fieldType.tag(), value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, FieldType fieldType, char value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, FieldType fieldType, char value) {
         if (fieldType.type() != DataType.CHAR) {
             throw new IllegalArgumentException("FieldType " + fieldType + " must be CHAR");
         }
         map.put(fieldType.tag(), new CharField(fieldType.tag(), value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, int tagNum, String value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, int tagNum, String value) {
         assert (tagNum > 0) : "TagNum must be positive. Got " + tagNum;
         assert (value != null) : "Value must be specified.";
         map.put(tagNum, FieldFactory.fromStringValue(tagNum, value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, DataType type, int tagNum, String value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, DataType type, int tagNum, String value) {
         assert (tagNum > 0) : "TagNum must be positive. Got " + tagNum;
         assert (value != null) : "Value must be specified.";
         map.put(tagNum, FieldFactory.fromStringValue(type, tagNum, value));
@@ -92,19 +91,19 @@ final class FieldListBuilderHelper {
 
     // From FixedPointNumber
 
-    static void add(Map<Integer, FixMessageFragment> map, FieldType fieldType, FixedPointNumber value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, FieldType fieldType, FixedPointNumber value) {
         assert (fieldType != null) : "Tag must be specified.";
         assert (value != null) : "Value must be specified.";
         map.put(fieldType.tag(), FieldFactory.fromFixedPointValue(fieldType.type(), fieldType.tag(), value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, int tagNum, FixedPointNumber value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, int tagNum, FixedPointNumber value) {
         assert (tagNum > 0) : "TagNum must be positive. Got " + tagNum;
         assert (value != null) : "Value must be specified.";
         map.put(tagNum, FieldFactory.fromFixedPointValue(tagNum, value));
     }
 
-    static void add(Map<Integer, FixMessageFragment> map, DataType type, int tagNum, FixedPointNumber value) {
+    static void add(Int2ObjectArrayMap<FixMessageFragment> map, DataType type, int tagNum, FixedPointNumber value) {
         assert (tagNum > 0) : "TagNum must be positive. Got " + tagNum;
         assert (value != null) : "Value must be specified.";
         map.put(tagNum, FieldFactory.fromFixedPointValue(type, tagNum, value));

--- a/core/src/main/java/fixio/fixprotocol/FixMessageBuilderImpl.java
+++ b/core/src/main/java/fixio/fixprotocol/FixMessageBuilderImpl.java
@@ -19,18 +19,17 @@ import fixio.fixprotocol.fields.CharField;
 import fixio.fixprotocol.fields.FixedPointNumber;
 import fixio.fixprotocol.fields.IntField;
 import fixio.fixprotocol.fields.StringField;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public class FixMessageBuilderImpl implements FixMessage, FixMessageBuilder {
 
     private static final int DEFAULT_BODY_FIELD_COUNT = 16;
     private final FixMessageHeader header;
     private final FixMessageTrailer trailer;
-    private final Map<Integer, FixMessageFragment> body;
+    private final Int2ObjectArrayMap<FixMessageFragment> body;
 
     /**
      * Creates FixMessageBuilderImpl with expected body field count.
@@ -38,20 +37,20 @@ public class FixMessageBuilderImpl implements FixMessage, FixMessageBuilder {
      * Providing expected capacity eliminates unnecessary growing of internal ArrayList storing body fields.
      */
     public FixMessageBuilderImpl(int expectedBodyFieldCount) {
-        header = new FixMessageHeader();
-        trailer = new FixMessageTrailer();
-        body = new LinkedHashMap<>(expectedBodyFieldCount);
+        this.header = new FixMessageHeader();
+        this.trailer = new FixMessageTrailer();
+        this.body = new Int2ObjectArrayMap<>(expectedBodyFieldCount);
     }
 
     /**
      * Creates FixMessageBuilderImpl with specified FixMessageHeader and  FixMessageTrailer.
      */
-    public FixMessageBuilderImpl(FixMessageHeader header, FixMessageTrailer trailer) {
+    public FixMessageBuilderImpl(FixMessageHeader header, final FixMessageTrailer trailer) {
         assert (header != null) : "FixMessageHeader is expected";
         assert (trailer != null) : "FixMessageTrailer is expected";
         this.header = header;
         this.trailer = trailer;
-        body = new LinkedHashMap<>(DEFAULT_BODY_FIELD_COUNT);
+        this.body = new Int2ObjectArrayMap<>(DEFAULT_BODY_FIELD_COUNT);
     }
 
     /**

--- a/core/src/main/java/fixio/fixprotocol/FixMessageImpl.java
+++ b/core/src/main/java/fixio/fixprotocol/FixMessageImpl.java
@@ -17,11 +17,10 @@
 package fixio.fixprotocol;
 
 import fixio.fixprotocol.fields.*;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Read-only view implementation of received {@link FixMessage}.
@@ -30,7 +29,7 @@ public class FixMessageImpl implements FixMessage {
 
     private final FixMessageHeader header = new FixMessageHeader();
     private final FixMessageTrailer trailer = new FixMessageTrailer();
-    private final Map<Integer, FixMessageFragment> body = new LinkedHashMap<>();
+    private final Int2ObjectArrayMap<FixMessageFragment> body = new Int2ObjectArrayMap<>();
 
     public FixMessageImpl add(int tagNum, byte[] value) {
         return add(tagNum, value, 0, value.length);

--- a/core/src/main/java/fixio/fixprotocol/Group.java
+++ b/core/src/main/java/fixio/fixprotocol/Group.java
@@ -17,11 +17,10 @@ package fixio.fixprotocol;
 
 import fixio.fixprotocol.fields.FixedPointNumber;
 import fixio.fixprotocol.fields.StringField;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents FIX Protocol field Group or Component - a sequence of Fields or other Groups.
@@ -29,14 +28,14 @@ import java.util.Map;
 public class Group implements FieldListBuilder<Group> {
 
     private static final int DEFAULT_GROUP_SIZE = 8;
-    private final Map<Integer, FixMessageFragment> contents;
+    private final Int2ObjectArrayMap<FixMessageFragment> contents;
 
     public Group(int expectedSize) {
-        this.contents = new LinkedHashMap<>(expectedSize);
+        this.contents = new Int2ObjectArrayMap<>(expectedSize);
     }
 
     public Group() {
-        this.contents = new LinkedHashMap<>(DEFAULT_GROUP_SIZE);
+        this.contents = new Int2ObjectArrayMap<>(DEFAULT_GROUP_SIZE);
     }
 
     public void add(FixMessageFragment element) {

--- a/core/src/main/xml/FieldType.xsl
+++ b/core/src/main/xml/FieldType.xsl
@@ -40,7 +40,7 @@
         */
         package fixio.fixprotocol;
 
-        import java.util.HashMap;
+        import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
         import static fixio.fixprotocol.DataType.*;
 
         public enum FieldType {
@@ -54,7 +54,7 @@
         private final DataType type;
         private final String[] enumValues;
 
-        private static final HashMap&lt;Integer,FieldType&gt; TYPES = new HashMap&lt;&gt;(FieldType.values().length);
+        private static final Int2ObjectArrayMap&lt;FieldType&gt; TYPES = new Int2ObjectArrayMap&lt;&gt;(FieldType.values().length);
 
         static {
             for (FieldType fieldType : FieldType.values()) {


### PR DESCRIPTION
This is a somewhat tentative pr as it means introducing [fast util](http://fastutil.di.unimi.it/) as a dependency. The reason for moving to using a primitive map is to remove the auto-boxing of the Integer key.

My goal would be to remove the boxing of Integer and Character on the FixMessage interface, but this would be a breaking change of the API so would involve deprecation on the interface, and introducing a special value as the ability to return null will be lost.