### PR TITLE
Set sendingTime before calling application

### DIFF
--- a/core/src/main/java/fixio/netty/pipeline/AbstractSessionHandler.java
+++ b/core/src/main/java/fixio/netty/pipeline/AbstractSessionHandler.java
@@ -86,8 +86,8 @@ public abstract class AbstractSessionHandler extends MessageToMessageCodec<FixMe
 
     protected void prepareMessageToSend(ChannelHandlerContext ctx, FixSession session, FixMessageBuilder response) throws Exception {
         session.prepareOutgoing(response);
-        getFixApplication().beforeSendMessage(ctx, response);
         response.getHeader().setSendingTime(fixClock.millis());
+        getFixApplication().beforeSendMessage(ctx, response);
     }
 
     /**


### PR DESCRIPTION
Allows for HMAC signing in Logon message required for gdax. https://docs.gdax.com/#logon